### PR TITLE
Add debug timing logs for gamepad initialization performance analysis

### DIFF
--- a/app/settings/mappingfetcher.cpp
+++ b/app/settings/mappingfetcher.cpp
@@ -20,6 +20,8 @@ MappingFetcher::MappingFetcher(QObject *parent) :
 
 void MappingFetcher::start()
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingFetcher::start() initiated");
+    
     if (!m_Nam) {
         Q_ASSERT(m_Nam);
         return;
@@ -63,11 +65,13 @@ void MappingFetcher::start()
 #endif
 
     // We'll get a callback when this is finished
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingFetcher network request started");
     m_Nam->get(request);
 }
 
 void MappingFetcher::handleMappingListFetched(QNetworkReply* reply)
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingFetcher network request completed");
     Q_ASSERT(reply->isFinished());
 
     // Delete the QNetworkAccessManager to free resources and

--- a/app/settings/mappingmanager.cpp
+++ b/app/settings/mappingmanager.cpp
@@ -68,10 +68,16 @@ void MappingManager::save()
 
 void MappingManager::applyMappings()
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingManager::applyMappings() started");
+    
     QByteArray mappingData = Path::readDataFile("gamecontrollerdb.txt");
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "gamecontrollerdb.txt read completed, size: %d bytes", mappingData.size());
+    
     if (!mappingData.isEmpty()) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Starting SDL_GameControllerAddMappingsFromRW...");
         int newMappings = SDL_GameControllerAddMappingsFromRW(
                     SDL_RWFromConstMem(mappingData.constData(), mappingData.size()), 1);
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL_GameControllerAddMappingsFromRW completed");
 
         if (newMappings > 0) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -98,6 +104,7 @@ void MappingManager::applyMappings()
                      "Unable to load gamepad mapping file");
     }
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Starting to apply %d user mappings", m_Mappings.size());
     QList<SdlGamepadMapping> mappings = m_Mappings.values();
     for (const SdlGamepadMapping& mapping : mappings) {
         QString sdlMappingString = mapping.getSdlMappingString();
@@ -113,6 +120,7 @@ void MappingManager::applyMappings()
                         qPrintable(sdlMappingString));
         }
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingManager::applyMappings() completed");
 }
 
 void MappingManager::addMapping(QString mappingString)

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -148,27 +148,35 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
     SDL_SetHint(SDL_HINT_GAMECONTROLLER_IGNORE_DEVICES, streamIgnoreDevices.toUtf8());
     SDL_SetHint(SDL_HINT_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT, streamIgnoreDevicesExcept.toUtf8());
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SdlInputHandler initialization sequence starting");
+    
     // We must initialize joystick explicitly before gamecontroller in order
     // to ensure we receive gamecontroller attach events for gamepads where
     // SDL doesn't have a built-in mapping. By starting joystick first, we
     // can allow mapping manager to update the mappings before GC attach
     // events are generated.
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initializing SDL_INIT_JOYSTICK subsystem");
     SDL_assert(!SDL_WasInit(SDL_INIT_JOYSTICK));
     if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) != 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "SDL_InitSubSystem(SDL_INIT_JOYSTICK) failed: %s",
                      SDL_GetError());
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL_INIT_JOYSTICK initialization completed");
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Starting gamepad mapping and controller initialization");
+    
     MappingManager mappingManager;
     mappingManager.applyMappings();
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Flushing gamepad events");
     // Flush gamepad arrival and departure events which may be queued before
     // starting the gamecontroller subsystem again. This prevents us from
     // receiving duplicate arrival and departure events for the same gamepad.
     SDL_FlushEvent(SDL_CONTROLLERDEVICEADDED);
     SDL_FlushEvent(SDL_CONTROLLERDEVICEREMOVED);
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initializing SDL_INIT_GAMECONTROLLER subsystem");
     // We need to reinit this each time, since you only get
     // an initial set of gamepad arrival events once per init.
     SDL_assert(!SDL_WasInit(SDL_INIT_GAMECONTROLLER));
@@ -177,6 +185,7 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
                      "SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) failed: %s",
                      SDL_GetError());
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL_INIT_GAMECONTROLLER initialization completed");
 
 #if !SDL_VERSION_ATLEAST(2, 0, 9)
     SDL_assert(!SDL_WasInit(SDL_INIT_HAPTIC));


### PR DESCRIPTION
- Added timing logs to MappingFetcher network requests
- Added timing logs to MappingManager::applyMappings() operations
- Added timing logs to SDL GameController initialization sequence
- Added timing logs to SdlInputHandler initialization process

These logs help identify performance bottlenecks during the 4-second delay between FFmpeg decoder initialization and gamepad mapping completion.

🤖 Generated with [Claude Code](https://claude.ai/code)