### PR TITLE
Add debug timing logs for gamepad initialization performance analysis

### DIFF
--- a/app/settings/mappingfetcher.cpp
+++ b/app/settings/mappingfetcher.cpp
@@ -2,6 +2,7 @@
 #include "path.h"
 
 #include <QNetworkReply>
+#include "SDL_compat.h"
 
 MappingFetcher::MappingFetcher(QObject *parent) :
     QObject(parent)

--- a/app/settings/mappingfetcher.cpp
+++ b/app/settings/mappingfetcher.cpp
@@ -20,6 +20,8 @@ MappingFetcher::MappingFetcher(QObject *parent) :
 
 void MappingFetcher::start()
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingFetcher::start() initiated");
+    
     if (!m_Nam) {
         Q_ASSERT(m_Nam);
         return;
@@ -63,11 +65,13 @@ void MappingFetcher::start()
 #endif
 
     // We'll get a callback when this is finished
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingFetcher network request started");
     m_Nam->get(request);
 }
 
 void MappingFetcher::handleMappingListFetched(QNetworkReply* reply)
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingFetcher network request completed");
     Q_ASSERT(reply->isFinished());
 
     // Delete the QNetworkAccessManager to free resources and

--- a/app/settings/mappingmanager.cpp
+++ b/app/settings/mappingmanager.cpp
@@ -68,10 +68,16 @@ void MappingManager::save()
 
 void MappingManager::applyMappings()
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingManager::applyMappings() started");
+    
     QByteArray mappingData = Path::readDataFile("gamecontrollerdb.txt");
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "gamecontrollerdb.txt read completed, size: %d bytes", mappingData.size());
+    
     if (!mappingData.isEmpty()) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Starting SDL_GameControllerAddMappingsFromRW...");
         int newMappings = SDL_GameControllerAddMappingsFromRW(
                     SDL_RWFromConstMem(mappingData.constData(), mappingData.size()), 1);
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL_GameControllerAddMappingsFromRW completed");
 
         if (newMappings > 0) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -98,6 +104,7 @@ void MappingManager::applyMappings()
                      "Unable to load gamepad mapping file");
     }
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Starting to apply %d user mappings", m_Mappings.size());
     QList<SdlGamepadMapping> mappings = m_Mappings.values();
     for (const SdlGamepadMapping& mapping : mappings) {
         QString sdlMappingString = mapping.getSdlMappingString();
@@ -113,6 +120,7 @@ void MappingManager::applyMappings()
                         qPrintable(sdlMappingString));
         }
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "MappingManager::applyMappings() completed");
 }
 
 void MappingManager::addMapping(QString mappingString)

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -148,27 +148,35 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
     SDL_SetHint(SDL_HINT_GAMECONTROLLER_IGNORE_DEVICES, streamIgnoreDevices.toUtf8());
     SDL_SetHint(SDL_HINT_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT, streamIgnoreDevicesExcept.toUtf8());
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SdlInputHandler initialization sequence starting");
+    
     // We must initialize joystick explicitly before gamecontroller in order
     // to ensure we receive gamecontroller attach events for gamepads where
     // SDL doesn't have a built-in mapping. By starting joystick first, we
     // can allow mapping manager to update the mappings before GC attach
     // events are generated.
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initializing SDL_INIT_JOYSTICK subsystem");
     SDL_assert(!SDL_WasInit(SDL_INIT_JOYSTICK));
     if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) != 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "SDL_InitSubSystem(SDL_INIT_JOYSTICK) failed: %s",
                      SDL_GetError());
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL_INIT_JOYSTICK initialization completed");
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Starting gamepad mapping and controller initialization");
+    
     MappingManager mappingManager;
     mappingManager.applyMappings();
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Flushing gamepad events");
     // Flush gamepad arrival and departure events which may be queued before
     // starting the gamecontroller subsystem again. This prevents us from
     // receiving duplicate arrival and departure events for the same gamepad.
     SDL_FlushEvent(SDL_CONTROLLERDEVICEADDED);
     SDL_FlushEvent(SDL_CONTROLLERDEVICEREMOVED);
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Initializing SDL_INIT_GAMECONTROLLER subsystem");
     // We need to reinit this each time, since you only get
     // an initial set of gamepad arrival events once per init.
     SDL_assert(!SDL_WasInit(SDL_INIT_GAMECONTROLLER));
@@ -177,6 +185,7 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
                      "SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) failed: %s",
                      SDL_GetError());
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL_INIT_GAMECONTROLLER initialization completed");
 
 #if !SDL_VERSION_ATLEAST(2, 0, 9)
     SDL_assert(!SDL_WasInit(SDL_INIT_HAPTIC));

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -290,6 +290,9 @@ bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
                             SDL_Window* window, int videoFormat, int width, int height,
                             int frameRate, bool enableVsync, bool enableFramePacing, bool enableVideoEnhancement, bool ignoreAspectRatio, bool testOnly, IVideoDecoder*& chosenDecoder)
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::chooseDecoder() starting - format: 0x%x, %dx%d, %d FPS", 
+                videoFormat, width, height, frameRate);
+    
     DECODER_PARAMETERS params;
 
     // We should never have vsync enabled for test-mode.
@@ -318,6 +321,7 @@ bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
     if (chosenDecoder->initialize(&params)) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "SLVideo video decoder chosen");
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::chooseDecoder() completed successfully - SLVideo");
         return true;
     }
     else {
@@ -333,6 +337,7 @@ bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
     if (chosenDecoder->initialize(&params)) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "FFmpeg-based video decoder chosen");
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::chooseDecoder() completed successfully - FFmpeg");
         return true;
     }
     else {
@@ -348,6 +353,7 @@ bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
 #endif
 
     // If we reach this, we didn't initialize any decoders successfully
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::chooseDecoder() failed - no decoder available");
     return false;
 }
 
@@ -512,6 +518,8 @@ Session::getDecoderAvailability(SDL_Window* window,
 
 bool Session::populateDecoderProperties(SDL_Window* window)
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::populateDecoderProperties() starting");
+    
     IVideoDecoder* decoder;
 
     if (!chooseDecoder(m_Preferences->videoDecoderSelection,
@@ -563,6 +571,8 @@ bool Session::populateDecoderProperties(SDL_Window* window)
 
     delete decoder;
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::populateDecoderProperties() completed");
+    
     return true;
 }
 
@@ -593,6 +603,8 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
 
 bool Session::initialize()
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::initialize() starting");
+    
 #ifdef Q_OS_DARWIN
     if (qEnvironmentVariableIntValue("I_WANT_BUGGY_FULLSCREEN") == 0) {
         // If we have a notch and the user specified one of the two native display modes
@@ -962,6 +974,8 @@ bool Session::initialize()
     // 启动带宽计算
     BandwidthCalculator::instance()->start();
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::initialize() completed");
+    
     return true;
 }
 
@@ -973,6 +987,8 @@ void Session::emitLaunchWarning(QString text)
 
 bool Session::validateLaunch(SDL_Window* testWindow)
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::validateLaunch() starting");
+    
     if (!m_Computer->isSupportedServerVersion) {
         emit displayLaunchError(tr("The version of GeForce Experience on %1 is not supported by this build of Moonlight. You must update Moonlight to stream from %1.").arg(m_Computer->name));
         return false;
@@ -1237,6 +1253,8 @@ bool Session::validateLaunch(SDL_Window* testWindow)
         return false;
     }
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::validateLaunch() completed");
+    
     return true;
 }
 
@@ -1785,6 +1803,8 @@ void Session::exec(QWindow* qtWindow)
 
 void Session::execInternal()
 {
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::execInternal() starting");
+    
     // Complete initialization in this deferred context to avoid
     // calling expensive functions in the constructor (during the
     // process of loading the StreamSegue).
@@ -1805,7 +1825,9 @@ void Session::execInternal()
 
     // Initialize the gamepad code with our preferences
     // NB: m_InputHandler must be initialize before starting the connection.
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Creating SdlInputHandler...");
     m_InputHandler = new SdlInputHandler(*m_Preferences, m_StreamConfig.width, m_StreamConfig.height);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SdlInputHandler created");
 
     AsyncConnectionStartThread asyncConnThread(this);
     if (!m_ThreadedExec) {

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -940,12 +940,15 @@ bool Session::initialize()
         ret = populateDecoderProperties(testWindow);
     }
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::SDL_DestroyWindow() starting");
     SDL_DestroyWindow(testWindow);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::SDL_DestroyWindow() completed");
 
     if (!ret) {
         SDL_QuitSubSystem(SDL_INIT_VIDEO);
         return false;
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::initialize() before configurationWarnings");
 
     if (m_Preferences->configurationWarnings) {
         // Display launch warnings in Qt only after destroying SDL's window.
@@ -970,6 +973,7 @@ bool Session::initialize()
             }
         }
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Session::initialize() before bandwidth start");
 
     // 启动带宽计算
     BandwidthCalculator::instance()->start();


### PR DESCRIPTION
- Added timing logs to MappingFetcher network requests
- Added timing logs to MappingManager::applyMappings() operations
- Added timing logs to SDL GameController initialization sequence
- Added timing logs to SdlInputHandler initialization process

These logs help identify performance bottlenecks during the 4-second delay between FFmpeg decoder initialization and gamepad mapping completion.

🤖 Generated with [Claude Code](https://claude.ai/code)